### PR TITLE
 Improve Formatting of Units in Information Table

### DIFF
--- a/src/test/webview/ui/infoTableComponent.test.ts
+++ b/src/test/webview/ui/infoTableComponent.test.ts
@@ -20,26 +20,26 @@ describe('infoTable', () => {
 
     test('show number of channel (mono)', () => {
         infoTableComponent.showInfo(1, 44100, 1, "s16", "pcm_s16le");
-        expect(document.getElementById('info-table-number_of_channel')?.textContent).toBe('1 (mono)');
+        expect(document.getElementById('info-table-number_of_channel')?.textContent).toBe('1 ch (mono)');
     });
 
     test('show number of channel (stereo)', () => {
         infoTableComponent.showInfo(2, 44100, 1, "s16", "pcm_s16le");
-        expect(document.getElementById('info-table-number_of_channel')?.textContent).toBe('2 (stereo)');
+        expect(document.getElementById('info-table-number_of_channel')?.textContent).toBe('2 ch (stereo)');
     });
 
     test('show sample rate', () => {
         infoTableComponent.showInfo(2, 44100, 1, "s16", "pcm_s16le");
-        expect(document.getElementById('info-table-sample_rate')?.textContent).toBe('44100');
+        expect(document.getElementById('info-table-sample_rate')?.textContent).toBe('44,100 Hz');
     });
 
     test('show file size', () => {
         infoTableComponent.showInfo(2, 44100, 1, "s16", "pcm_s16le");
-        expect(document.getElementById('info-table-file_size')?.textContent).toBe('1 byte');
+        expect(document.getElementById('info-table-file_size')?.textContent).toBe('1 bytes');
     });
 
     test('show duration', () => {
         infoTableComponent.showAdditionalInfo(12.34);
-        expect(document.getElementById('info-table-duration')?.textContent).toBe('12.34s');
+        expect(document.getElementById('info-table-duration')?.textContent).toBe('12.3 s');
     });
 });

--- a/src/webview/ui/infoTableComponent.ts
+++ b/src/webview/ui/infoTableComponent.ts
@@ -15,9 +15,9 @@ export default class InfoTableComponent {
         const info = [
             { name: "encoding", value: `${encoding}` },
             { name: "format", value: `${format}` },
-            { name: "number_of_channel", value: `${numChannels} (${channels})` },
-            { name: "sample_rate", value: `${sampleRate}` },
-            { name: "file_size", value: `${fileSize} byte` },
+            { name: "number_of_channel", value: `${numChannels} ch (${channels})` },
+            { name: "sample_rate", value: `${sampleRate.toLocaleString()} Hz` },
+            { name: "file_size", value: `${fileSize.toLocaleString()} bytes` },
         ];
 
         // clear info table
@@ -32,7 +32,7 @@ export default class InfoTableComponent {
     }
 
     public showAdditionalInfo(duration: number) {
-        this.insertTableData("duration", duration + "s");
+        this.insertTableData("duration", duration.toLocaleString(undefined, { maximumFractionDigits: 1 }) + " s");
     }
 
     private insertTableData(name: string, value: string) {


### PR DESCRIPTION
This pull request introduces changes to enhance the formatting of the units in the information table.

## Purpose of Change
* Improve visibility and readability of the information table.

## Changes
* Numbers are now formatted with commas for thousands and all units are shown in a consistent manner.

![pr_info_table](https://github.com/sukumo28/vscode-audio-preview/assets/2169305/0c5d470c-b442-4a13-b6a0-62cd486752a2)

## Tests
* I've confirmed the change visually.
* Some tests in infoTableComponent.test.ts have been changed to test new formats.
* The changes conform to all existing tests, including the modified tests.

As I am new to the VSCode extension, TypeScript, and GitHub practices, I welcome any feedback.
