### PR TITLE
Improve Player Usability

### DIFF
--- a/README.md
+++ b/README.md
@@ -41,7 +41,21 @@ You can configure default value of player settings like example below.
         true: dB scale, false: linear scale
         default: true
     */
-    "volumeUnitDb": true
+    "volumeUnitDb": true,
+    
+    /*
+        Initial player volume in dB scale. [-80.0, 0.0]
+        This setting is valid when volumeUnitDb is true.
+        default: 0.0
+    */
+    "initVolumeDb": 0.0,
+    
+    /*
+        Initial player volume in linear scale. [0, 100]
+        This setting is valid when volumeUnitDb is false.
+        default: 100
+    */
+    "initVolumeDb": 100
 }
 ```
 

--- a/README.md
+++ b/README.md
@@ -33,6 +33,18 @@ You can analyze audio automatically when you open it.
 "WavPreview.autoAnalyze": true
 ```
 
+You can configure default value of player settings like example below.
+```jsonc
+"WavPreview.playerDefault": {
+    /*
+        Choose the scale of the volume bar
+        true: dB scale, false: linear scale
+        default: true
+    */
+    "volumeUnitDb": true
+}
+```
+
 You can configure default value of analyze settings like example below.  
 ```jsonc
 "WavPreview.analyzeDefault": {

--- a/README.md
+++ b/README.md
@@ -44,9 +44,9 @@ You can configure default value of player settings like example below.
     /*
         Choose the scale of the volume bar
         true: dB scale, false: linear scale
-        default: true
+        default: false
     */
-    "volumeUnitDb": true,
+    "volumeUnitDb": false,
     
     /*
         Initial player volume in dB scale. [-80.0, 0.0]

--- a/package.json
+++ b/package.json
@@ -75,6 +75,11 @@
 					"default": false,
 					"description": "automatically analyze audio file when you open it"
 				},
+				"WavPreview.playerDefault": {
+					"type": "object",
+					"default": {},
+					"description": "default values of player settings"
+				},
 				"WavPreview.analyzeDefault": {
 					"type": "object",
 					"default": {},

--- a/src/audioPreviewEditor.ts
+++ b/src/audioPreviewEditor.ts
@@ -1,7 +1,7 @@
 import * as vscode from "vscode";
 import { Disposable, disposeAll } from "./dispose";
 import { getNonce } from "./util";
-import { AnalyzeDefault } from "./config";
+import { AnalyzeDefault, PlayerDefault } from "./config";
 import { ExtMessage, ExtMessageType, WebviewMessage, WebviewMessageType } from "./message";
 
 class AudioPreviewDocument extends Disposable implements vscode.CustomDocument {
@@ -143,6 +143,7 @@ export class AudioPreviewEditorProvider implements vscode.CustomReadonlyEditorPr
                     type: ExtMessageType.Config,
                     data: {
                         autoAnalyze: config.get("autoAnalyze"),
+                        playerDefault: config.get("playerDefault") as PlayerDefault,
                         analyzeDefault: config.get("analyzeDefault") as AnalyzeDefault
                     }
                 });

--- a/src/config.ts
+++ b/src/config.ts
@@ -6,6 +6,8 @@ export interface Config {
 
 export interface PlayerDefault {
     volumeUnitDb: boolean;
+    initVolumeDb: number;
+    initVolume: number;
 }
 
 export interface AnalyzeDefault {

--- a/src/config.ts
+++ b/src/config.ts
@@ -1,6 +1,11 @@
 export interface Config {
     autoAnalyze: boolean,
+    playerDefault: PlayerDefault,
     analyzeDefault: AnalyzeDefault,
+}
+
+export interface PlayerDefault {
+    volumeUnitDb: boolean;
 }
 
 export interface AnalyzeDefault {

--- a/src/test/webview/service/playerSettingsService.test.ts
+++ b/src/test/webview/service/playerSettingsService.test.ts
@@ -12,17 +12,18 @@ describe("fromDefaultSettings", () => {
     });
 
     // volumeUnitDb
-    test("volumeUnitDb should be true if no default value is provided", () => {
+    test("volumeUnitDb should be false if no default value is provided", () => {
+        const ps = PlayerSettingService.fromDefaultSetting(defaultSettings);
+        expect(ps.volumeUnitDb).toBe(false);
+    });
+    test("volumeUnitDb should be default value (true case)", () => {
+        defaultSettings.volumeUnitDb = true;
         const ps = PlayerSettingService.fromDefaultSetting(defaultSettings);
         expect(ps.volumeUnitDb).toBe(true);
     });
-    test("volumeUnitDb should be default value", () => {
-        defaultSettings.volumeUnitDb = true;
-        let ps = PlayerSettingService.fromDefaultSetting(defaultSettings);
-        expect(ps.volumeUnitDb).toBe(true);
-
+    test("volumeUnitDb should be default value (false case)", () => {
         defaultSettings.volumeUnitDb = false;
-        ps = PlayerSettingService.fromDefaultSetting(defaultSettings);
+        const ps = PlayerSettingService.fromDefaultSetting(defaultSettings);
         expect(ps.volumeUnitDb).toBe(false);
     });
 

--- a/src/test/webview/service/playerSettingsService.test.ts
+++ b/src/test/webview/service/playerSettingsService.test.ts
@@ -1,0 +1,26 @@
+import { PlayerDefault } from "../../../config";
+import PlayerSettingService from "../../../webview/service/playerSettingsService";
+
+describe("fromDefaultSettings", () => {
+    let defaultSettings: PlayerDefault;
+    beforeEach(() => {
+        defaultSettings = { 
+            volumeUnitDb: undefined
+        };
+    });
+
+    // windowSizeIndex
+    test("volumeUnitDb should be true if no default value is provided", () => {
+        const ps = PlayerSettingService.fromDefaultSetting(defaultSettings);
+        expect(ps.volumeUnitDb).toBe(true);
+    });
+    test("volumeUnitDb should be default value", () => {
+        defaultSettings.volumeUnitDb = true;
+        let ps = PlayerSettingService.fromDefaultSetting(defaultSettings);
+        expect(ps.volumeUnitDb).toBe(true);
+
+        defaultSettings.volumeUnitDb = false;
+        ps = PlayerSettingService.fromDefaultSetting(defaultSettings);
+        expect(ps.volumeUnitDb).toBe(false);
+    });
+});

--- a/src/test/webview/service/playerSettingsService.test.ts
+++ b/src/test/webview/service/playerSettingsService.test.ts
@@ -5,11 +5,13 @@ describe("fromDefaultSettings", () => {
     let defaultSettings: PlayerDefault;
     beforeEach(() => {
         defaultSettings = { 
-            volumeUnitDb: undefined
+            volumeUnitDb: undefined,
+            initVolumeDb: undefined,
+            initVolume: undefined,
         };
     });
 
-    // windowSizeIndex
+    // volumeUnitDb
     test("volumeUnitDb should be true if no default value is provided", () => {
         const ps = PlayerSettingService.fromDefaultSetting(defaultSettings);
         expect(ps.volumeUnitDb).toBe(true);
@@ -22,5 +24,45 @@ describe("fromDefaultSettings", () => {
         defaultSettings.volumeUnitDb = false;
         ps = PlayerSettingService.fromDefaultSetting(defaultSettings);
         expect(ps.volumeUnitDb).toBe(false);
+    });
+
+    // initVolumeDb
+    test("initVolumeDb should be 0.0 if no default value is provided", () => {
+        const ps = PlayerSettingService.fromDefaultSetting(defaultSettings);
+        expect(ps.initVolumeDb).toBe(0.0);
+    });
+    test("initVolumeDb should be default value", () => {
+        defaultSettings.initVolumeDb = -20.0;
+        let ps = PlayerSettingService.fromDefaultSetting(defaultSettings);
+        expect(ps.initVolumeDb).toBe(-20.0);
+    });
+    test("initVolumeDb should be in valid range", () => {
+        defaultSettings.initVolumeDb = -100.0;
+        let ps = PlayerSettingService.fromDefaultSetting(defaultSettings);
+        expect(ps.initVolumeDb).toBe(PlayerSettingService.VOLUME_DB_MIN);
+
+        defaultSettings.initVolumeDb = 10.0;
+        ps = PlayerSettingService.fromDefaultSetting(defaultSettings);
+        expect(ps.initVolumeDb).toBe(PlayerSettingService.VOLUME_DB_MAX);
+    });
+
+    // initVolume
+    test("initVolume should be 100 if no default value is provided", () => {
+        const ps = PlayerSettingService.fromDefaultSetting(defaultSettings);
+        expect(ps.initVolume).toBe(100);
+    });
+    test("initVolume should be default value", () => {
+        defaultSettings.initVolume = 50;
+        let ps = PlayerSettingService.fromDefaultSetting(defaultSettings);
+        expect(ps.initVolume).toBe(50);
+    });
+    test("initVolume should be in valid range", () => {
+        defaultSettings.initVolume = -10;
+        let ps = PlayerSettingService.fromDefaultSetting(defaultSettings);
+        expect(ps.initVolume).toBe(PlayerSettingService.VOLUME_MIN);
+
+        defaultSettings.initVolume = 200;
+        ps = PlayerSettingService.fromDefaultSetting(defaultSettings);
+        expect(ps.initVolume).toBe(PlayerSettingService.VOLUME_MAX);
     });
 });

--- a/src/test/webview/service/playerSettingsService.test.ts
+++ b/src/test/webview/service/playerSettingsService.test.ts
@@ -16,12 +16,12 @@ describe("fromDefaultSettings", () => {
         const ps = PlayerSettingService.fromDefaultSetting(defaultSettings);
         expect(ps.volumeUnitDb).toBe(false);
     });
-    test("volumeUnitDb should be default value (true case)", () => {
+    test("volumeUnitDb should be true if default value is true", () => {
         defaultSettings.volumeUnitDb = true;
         const ps = PlayerSettingService.fromDefaultSetting(defaultSettings);
         expect(ps.volumeUnitDb).toBe(true);
     });
-    test("volumeUnitDb should be default value (false case)", () => {
+    test("volumeUnitDb should be false if default value is false", () => {
         defaultSettings.volumeUnitDb = false;
         const ps = PlayerSettingService.fromDefaultSetting(defaultSettings);
         expect(ps.volumeUnitDb).toBe(false);
@@ -34,16 +34,17 @@ describe("fromDefaultSettings", () => {
     });
     test("initVolumeDb should be default value", () => {
         defaultSettings.initVolumeDb = -20.0;
-        let ps = PlayerSettingService.fromDefaultSetting(defaultSettings);
+        const ps = PlayerSettingService.fromDefaultSetting(defaultSettings);
         expect(ps.initVolumeDb).toBe(-20.0);
     });
-    test("initVolumeDb should be in valid range", () => {
+    test("initVolumeDb should be in valid range (check lower limit)", () => {
         defaultSettings.initVolumeDb = -100.0;
-        let ps = PlayerSettingService.fromDefaultSetting(defaultSettings);
+        const ps = PlayerSettingService.fromDefaultSetting(defaultSettings);
         expect(ps.initVolumeDb).toBe(PlayerSettingService.VOLUME_DB_MIN);
-
+    });
+    test("initVolumeDb should be in valid range (check upper limit)", () => {
         defaultSettings.initVolumeDb = 10.0;
-        ps = PlayerSettingService.fromDefaultSetting(defaultSettings);
+        const ps = PlayerSettingService.fromDefaultSetting(defaultSettings);
         expect(ps.initVolumeDb).toBe(PlayerSettingService.VOLUME_DB_MAX);
     });
 
@@ -54,16 +55,17 @@ describe("fromDefaultSettings", () => {
     });
     test("initVolume should be default value", () => {
         defaultSettings.initVolume = 50;
-        let ps = PlayerSettingService.fromDefaultSetting(defaultSettings);
+        const ps = PlayerSettingService.fromDefaultSetting(defaultSettings);
         expect(ps.initVolume).toBe(50);
     });
-    test("initVolume should be in valid range", () => {
+    test("initVolume should be in valid range (check lower limit)", () => {
         defaultSettings.initVolume = -10;
-        let ps = PlayerSettingService.fromDefaultSetting(defaultSettings);
+        const ps = PlayerSettingService.fromDefaultSetting(defaultSettings);
         expect(ps.initVolume).toBe(PlayerSettingService.VOLUME_MIN);
-
-        defaultSettings.initVolume = 200;
-        ps = PlayerSettingService.fromDefaultSetting(defaultSettings);
-        expect(ps.initVolume).toBe(PlayerSettingService.VOLUME_MAX);
     });
+    test("initVolume should be in valid range (check upper limit)", () => {
+        defaultSettings.initVolume = 200;
+        const ps = PlayerSettingService.fromDefaultSetting(defaultSettings);
+        expect(ps.initVolume).toBe(PlayerSettingService.VOLUME_MAX);
+    });    
 });

--- a/src/test/webview/ui/playerComponent.test.ts
+++ b/src/test/webview/ui/playerComponent.test.ts
@@ -13,7 +13,9 @@ describe('player', () => {
         const audioContext = createAudioContext(44100);
         const audioBuffer = audioContext.createBuffer(2, 44100, 44100);
         const pd = {
-            volumeUnitDb: undefined
+            volumeUnitDb: undefined,
+            initVolumeDb: 0.0,
+            initVolume: 1.0,
         }
         playerService = new PlayerService(audioContext, audioBuffer);
         playerSettingService = PlayerSettingsService.fromDefaultSetting(pd);
@@ -79,7 +81,9 @@ describe('player', () => {
         const audioContext = createAudioContext(44100);
         const audioBuffer = audioContext.createBuffer(2, 44100, 44100);
         const pd = {
-            volumeUnitDb: false
+            volumeUnitDb: false,
+            initVolumeDb: 0.0,
+            initVolume: 1.0,
         }
         playerService = new PlayerService(audioContext, audioBuffer);
         playerSettingService = PlayerSettingsService.fromDefaultSetting(pd);

--- a/src/test/webview/ui/playerComponent.test.ts
+++ b/src/test/webview/ui/playerComponent.test.ts
@@ -25,11 +25,13 @@ describe('player', () => {
 
     test('player should have volume bar', () => {
         expect(document.getElementById('volume-bar')).toBeTruthy();
+        expect(document.getElementById('volume-text')).toBeTruthy();
     });
 
     test('player should have seek bar', () => {
         expect(document.getElementById('seek-bar')).toBeTruthy();
         expect(document.getElementById('user-input-seek-bar')).toBeTruthy();
+        expect(document.getElementById('seek-pos-text')).toBeTruthy();
     });
 
     test('dispatch update-seekbar event when user change user-input-seek-bar', async () => {
@@ -53,9 +55,15 @@ describe('player', () => {
 
     test('change volume when volume-bar is changed', () => {
         const volumeBar = <HTMLInputElement>document.getElementById("volume-bar");
-        volumeBar.value = "50";
-        volumeBar.dispatchEvent(new Event('change'));
-        expect(playerService.volume).toBe(0.5);
+        volumeBar.value = "0";
+        volumeBar.dispatchEvent(new Event('input'));
+        expect(playerService.volume).toBe(1.0);
+        volumeBar.value = "-20";
+        volumeBar.dispatchEvent(new Event('input'));
+        expect(playerService.volume).toBe(0.1);
+        volumeBar.value = "-80";
+        volumeBar.dispatchEvent(new Event('input'));
+        expect(playerService.volume).toBe(0.0);
     });
 
     test('play when play button is clicked while not playing', () => {

--- a/src/test/webview/ui/playerComponent.test.ts
+++ b/src/test/webview/ui/playerComponent.test.ts
@@ -5,130 +5,139 @@ import PlayerComponent from "../../../webview/ui/playerComponent";
 import { createAudioContext, waitEventForAction } from "../../helper";
 
 describe('player', () => {
-    let playerService: PlayerService;
-    let playerSettingService: PlayerSettingsService;
-    let playerComponent: PlayerComponent;
-    beforeAll(() => {
-        document.body.innerHTML = '<div id="player"></div>';
-        const audioContext = createAudioContext(44100);
-        const audioBuffer = audioContext.createBuffer(2, 44100, 44100);
-        const pd = {
-            volumeUnitDb: undefined,
-            initVolumeDb: 0.0,
-            initVolume: 1.0,
-        }
-        playerService = new PlayerService(audioContext, audioBuffer);
-        playerSettingService = PlayerSettingsService.fromDefaultSetting(pd);
-        playerComponent = new PlayerComponent("player", playerService, playerSettingService);
-    });
-
-    afterAll(() => {
-        playerComponent.dispose();
-        playerService.dispose();
-    });
-
-    test('player should have play button', () => {
-        expect(document.getElementById('play-button')).toBeTruthy();
-    });
-
-    test('player should have volume bar', () => {
-        expect(document.getElementById('volume-bar')).toBeTruthy();
-        expect(document.getElementById('volume-text')).toBeTruthy();
-    });
-
-    test('player should have seek bar', () => {
-        expect(document.getElementById('seek-bar')).toBeTruthy();
-        expect(document.getElementById('user-input-seek-bar')).toBeTruthy();
-        expect(document.getElementById('seek-pos-text')).toBeTruthy();
-    });
-
-    test('dispatch update-seekbar event when user change user-input-seek-bar', async () => {
-        const detail = await waitEventForAction(() => {
-            const userinputSeekbar = <HTMLInputElement>document.getElementById("user-input-seek-bar");
-            userinputSeekbar.value = "50";
-            userinputSeekbar.dispatchEvent(new Event('change'));
-        }, window, EventType.UpdateSeekbar);
-        expect(detail.value).toBeGreaterThanOrEqual(50);
-    });
-
-    test('update visible-seekbar when seekbar value is updated', () => {
-        const visibleSeekbar = <HTMLInputElement>document.getElementById("seek-bar");
-        window.dispatchEvent(new CustomEvent(EventType.UpdateSeekbar, {
-            detail: {
-                value: 50
+    describe('general test with "volumeUnitDb = false"', () => {
+        let playerService: PlayerService;
+        let playerSettingService: PlayerSettingsService;
+        let playerComponent: PlayerComponent;
+        beforeAll(() => {
+            document.body.innerHTML = '<div id="player"></div>';
+            const audioContext = createAudioContext(44100);
+            const audioBuffer = audioContext.createBuffer(2, 44100, 44100);
+            const pd = {
+                volumeUnitDb: undefined,
+                initVolumeDb: 0.0,
+                initVolume: 1.0,
             }
-        }));
-        expect(visibleSeekbar.value).toBe('50');
+            playerService = new PlayerService(audioContext, audioBuffer);
+            playerSettingService = PlayerSettingsService.fromDefaultSetting(pd);
+            playerComponent = new PlayerComponent("player", playerService, playerSettingService);
+        });
+
+        afterAll(() => {
+            playerComponent.dispose();
+            playerService.dispose();
+        });
+
+        test('player should have play button', () => {
+            expect(document.getElementById('play-button')).toBeTruthy();
+        });
+
+        test('player should have volume bar', () => {
+            expect(document.getElementById('volume-bar')).toBeTruthy();
+            expect(document.getElementById('volume-text')).toBeTruthy();
+        });
+
+        test('player should have seek bar', () => {
+            expect(document.getElementById('seek-bar')).toBeTruthy();
+            expect(document.getElementById('user-input-seek-bar')).toBeTruthy();
+            expect(document.getElementById('seek-pos-text')).toBeTruthy();
+        });
+
+        test('dispatch update-seekbar event when user change user-input-seek-bar', async () => {
+            const detail = await waitEventForAction(() => {
+                const userinputSeekbar = <HTMLInputElement>document.getElementById("user-input-seek-bar");
+                userinputSeekbar.value = "50";
+                userinputSeekbar.dispatchEvent(new Event('change'));
+            }, window, EventType.UpdateSeekbar);
+            expect(detail.value).toBeGreaterThanOrEqual(50);
+        });
+
+        test('update visible-seekbar when seekbar value is updated', () => {
+            const visibleSeekbar = <HTMLInputElement>document.getElementById("seek-bar");
+            window.dispatchEvent(new CustomEvent(EventType.UpdateSeekbar, {
+                detail: {
+                    value: 50
+                }
+            }));
+            expect(visibleSeekbar.value).toBe('50');
+        });
+
+        test('change volume when volume-bar is changed (volumeUnitDb = false)', () => {
+            const volumeBar = <HTMLInputElement>document.getElementById("volume-bar");
+            volumeBar.value = "100";
+            volumeBar.dispatchEvent(new Event('input'));
+            expect(playerService.volume).toBe(1.0);
+            volumeBar.value = "50";
+            volumeBar.dispatchEvent(new Event('input'));
+            expect(playerService.volume).toBe(0.5);
+            volumeBar.value = "0";
+            volumeBar.dispatchEvent(new Event('input'));
+            expect(playerService.volume).toBe(0.0);
+        });
+
+        test('play when play button is clicked while not playing', () => {
+            if(playerService.isPlaying) playerService.pause();
+            const playButton = <HTMLButtonElement>document.getElementById("play-button");
+            playButton.dispatchEvent(new Event('click'));
+            expect(playerService.isPlaying).toBe(true);
+        });
+
+        test('pause when play button is clicked while playing', () => {
+            playerService.play();
+            const playButton = <HTMLButtonElement>document.getElementById("play-button");
+            playButton.dispatchEvent(new Event('click'));
+            expect(playerService.isPlaying).toBe(false);
+        });
+
+        test('change text of play button when playing status is updated', () => {
+            if(playerService.isPlaying) playerService.pause();
+            const playButton = <HTMLButtonElement>document.getElementById("play-button");
+            expect(playButton.textContent).toBe('play');
+            playerService.play();
+            expect(playButton.textContent).toBe('pause');
+        });
+
+        test('play when space key is pressed while not playing', () => {
+            if(playerService.isPlaying) playerService.pause();
+            window.dispatchEvent(new KeyboardEvent('keydown', { isComposing: false, code: 'Space' }));
+            expect(playerService.isPlaying).toBe(true);
+        });
     });
 
-    test('change volume when volume-bar is changed', () => {
-        let volumeBar = <HTMLInputElement>document.getElementById("volume-bar");
+    describe('additional test for "volumeUnitDb = true"', () => {
+        let playerService: PlayerService;
+        let playerSettingService: PlayerSettingsService;
+        let playerComponent: PlayerComponent;
+        beforeAll(() => {
+            document.body.innerHTML = '<div id="player"></div>';
+            const audioContext = createAudioContext(44100);
+            const audioBuffer = audioContext.createBuffer(2, 44100, 44100);
+            const pd = {
+                volumeUnitDb: true,     // test true case
+                initVolumeDb: 0.0,
+                initVolume: 1.0,
+            }
+            playerService = new PlayerService(audioContext, audioBuffer);
+            playerSettingService = PlayerSettingsService.fromDefaultSetting(pd);
+            playerComponent = new PlayerComponent("player", playerService, playerSettingService);
+        });
 
-        volumeBar.value = "0";
-        volumeBar.dispatchEvent(new Event('input'));
-        expect(playerService.volume).toBe(1.0);
-        volumeBar.value = "-20";
-        volumeBar.dispatchEvent(new Event('input'));
-        expect(playerService.volume).toBe(0.1);
-        volumeBar.value = "-80";
-        volumeBar.dispatchEvent(new Event('input'));
-        expect(playerService.volume).toBe(0.0);
+        afterAll(() => {
+            playerComponent.dispose();
+            playerService.dispose();
+        });
 
-        playerComponent.dispose();
-        playerService.dispose();
-
-        // create playerComponent again to change setting
-        const audioContext = createAudioContext(44100);
-        const audioBuffer = audioContext.createBuffer(2, 44100, 44100);
-        const pd = {
-            volumeUnitDb: false,
-            initVolumeDb: 0.0,
-            initVolume: 1.0,
-        }
-        playerService = new PlayerService(audioContext, audioBuffer);
-        playerSettingService = PlayerSettingsService.fromDefaultSetting(pd);
-        playerComponent = new PlayerComponent("player", playerService, playerSettingService);
-
-        volumeBar = <HTMLInputElement>document.getElementById("volume-bar");
-
-        volumeBar.value = "100";
-        volumeBar.dispatchEvent(new Event('input'));
-        expect(playerService.volume).toBe(1.0);
-        volumeBar.value = "50";
-        volumeBar.dispatchEvent(new Event('input'));
-        expect(playerService.volume).toBe(0.5);
-        volumeBar.value = "0";
-        volumeBar.dispatchEvent(new Event('input'));
-        expect(playerService.volume).toBe(0.0);
+        test('change volume when volume-bar is changed (volumeUnitDb = true)', () => {
+            const volumeBar = <HTMLInputElement>document.getElementById("volume-bar");
+            volumeBar.value = "0";
+            volumeBar.dispatchEvent(new Event('input'));
+            expect(playerService.volume).toBe(1.0);
+            volumeBar.value = "-20";
+            volumeBar.dispatchEvent(new Event('input'));
+            expect(playerService.volume).toBe(0.1);
+            volumeBar.value = "-80";
+            volumeBar.dispatchEvent(new Event('input'));
+            expect(playerService.volume).toBe(0.0);
+        });
     });
-
-    test('play when play button is clicked while not playing', () => {
-        if(playerService.isPlaying) playerService.pause();
-        const playButton = <HTMLButtonElement>document.getElementById("play-button");
-        playButton.dispatchEvent(new Event('click'));
-        expect(playerService.isPlaying).toBe(true);
-    });
-
-    test('pause when play button is clicked while playing', () => {
-        playerService.play();
-        const playButton = <HTMLButtonElement>document.getElementById("play-button");
-        playButton.dispatchEvent(new Event('click'));
-        expect(playerService.isPlaying).toBe(false);
-    });
-
-    test('change text of play button when playing status is updated', () => {
-        if(playerService.isPlaying) playerService.pause();
-        const playButton = <HTMLButtonElement>document.getElementById("play-button");
-        expect(playButton.textContent).toBe('play');
-        playerService.play();
-        expect(playButton.textContent).toBe('pause');
-    });
-
-    test('play when space key is pressed while not playing', () => {
-        if(playerService.isPlaying) playerService.pause();
-        window.dispatchEvent(new KeyboardEvent('keydown', { isComposing: false, code: 'Space' }));
-        expect(playerService.isPlaying).toBe(true);
-    });
-
 });
-

--- a/src/test/webview/ui/webview.test.ts
+++ b/src/test/webview/ui/webview.test.ts
@@ -45,7 +45,9 @@ describe('webview lifecycle', () => {
             postMessageFromExt({ type: ExtMessageType.Config, data: { 
                 autoAnalyze: false,
                 playerDefault: {
-                    volumeUnitDb: undefined
+                    volumeUnitDb: undefined,
+                    initVolumeDb: 0.0,
+                    initVolume: 1.0,
                 },
                 analyzeDefault: { 
                     windowSizeIndex: undefined, 
@@ -147,7 +149,9 @@ describe('webview error handling', () => {
             postMessageFromExt({ type: ExtMessageType.Config, data: { 
                 autoAnalyze: false,
                 playerDefault: {
-                    volumeUnitDb: undefined
+                    volumeUnitDb: undefined,
+                    initVolumeDb: 0.0,
+                    initVolume: 1.0,
                 },
                 analyzeDefault: { 
                     windowSizeIndex: undefined, 

--- a/src/test/webview/ui/webview.test.ts
+++ b/src/test/webview/ui/webview.test.ts
@@ -44,6 +44,9 @@ describe('webview lifecycle', () => {
         const msg = await waitVSCodeMessageForAction(() => {
             postMessageFromExt({ type: ExtMessageType.Config, data: { 
                 autoAnalyze: false,
+                playerDefault: {
+                    volumeUnitDb: undefined
+                },
                 analyzeDefault: { 
                     windowSizeIndex: undefined, 
                     minAmplitude: undefined, 
@@ -143,6 +146,9 @@ describe('webview error handling', () => {
         await waitVSCodeMessageForAction(() => {
             postMessageFromExt({ type: ExtMessageType.Config, data: { 
                 autoAnalyze: false,
+                playerDefault: {
+                    volumeUnitDb: undefined
+                },
                 analyzeDefault: { 
                     windowSizeIndex: undefined, 
                     minAmplitude: undefined, 

--- a/src/webview/events.ts
+++ b/src/webview/events.ts
@@ -21,6 +21,7 @@ export const EventType = {
     // other
     Click: "click",
     Change: "change",
+    Input: "input",
     KeyDown: "keydown"
 };
 

--- a/src/webview/service/playerService.ts
+++ b/src/webview/service/playerService.ts
@@ -93,7 +93,8 @@ export default class PlayerService extends Disposable {
         // update seek bar value
         const updateSeekbarEvent = new CustomEvent(EventType.UpdateSeekbar, {
             detail: {
-                value: this._seekbarValue
+                value: this._seekbarValue,
+                pos: current
             }
         });
         window.dispatchEvent(updateSeekbarEvent);

--- a/src/webview/service/playerSettingsService.ts
+++ b/src/webview/service/playerSettingsService.ts
@@ -1,22 +1,53 @@
 import { PlayerDefault } from "../../config";
 
 export default class PlayerSettingsService {
+    public static VOLUME_DB_MAX = 0.0;
+    public static VOLUME_DB_MIN = -80.0;
+    public static VOLUME_MAX = 100;
+    public static VOLUME_MIN = 0;
+
     private _volumeUnitDb: boolean;
     public get volumeUnitDb() { return this._volumeUnitDb; }
     public set volumeUnitDb(value: boolean) { 
         this._volumeUnitDb = value == undefined ? true : value;      // true by default
     }
 
-    private constructor(volumeUnitDb: boolean) {
+    private _initVolumeDb: number;
+    public get initVolumeDb() { return this._initVolumeDb; }
+    public set initVolumeDb(value: number) { 
+        let val = value == undefined ? PlayerSettingsService.VOLUME_DB_MAX : value;      // max by default
+
+        if (val < PlayerSettingsService.VOLUME_DB_MIN) val = PlayerSettingsService.VOLUME_DB_MIN;
+        if (PlayerSettingsService.VOLUME_DB_MAX < val) val = PlayerSettingsService.VOLUME_DB_MAX; 
+        this._initVolumeDb = val;
+    }
+
+    private _initVolume: number;
+    public get initVolume() { return this._initVolume; }
+    public set initVolume(value: number) { 
+        let val = value == undefined ? PlayerSettingsService.VOLUME_MAX : value;      // max by default
+
+        if (val < PlayerSettingsService.VOLUME_MIN) val = PlayerSettingsService.VOLUME_MIN;
+        if (PlayerSettingsService.VOLUME_MAX < val) val = PlayerSettingsService.VOLUME_MAX; 
+        this._initVolume = val;
+    }
+
+    private constructor(volumeUnitDb: boolean, initVolumeDb: number, initVolume: number) {
         this._volumeUnitDb = volumeUnitDb;
+        this._initVolumeDb = initVolumeDb;
+        this._initVolume = initVolume;
     }
 
     public static fromDefaultSetting(defaultSetting: PlayerDefault) {
         // create instance
-        const setting = new PlayerSettingsService(true);
+        const setting = new PlayerSettingsService(true, 0.0, 1.0);
 
         // init volume unit
         setting.volumeUnitDb = defaultSetting.volumeUnitDb;
+
+        // init initial volume
+        setting.initVolumeDb = defaultSetting.initVolumeDb;
+        setting.initVolume = defaultSetting.initVolume;
 
         return setting;
     }

--- a/src/webview/service/playerSettingsService.ts
+++ b/src/webview/service/playerSettingsService.ts
@@ -1,0 +1,23 @@
+import { PlayerDefault } from "../../config";
+
+export default class PlayerSettingsService {
+    private _volumeUnitDb: boolean;
+    public get volumeUnitDb() { return this._volumeUnitDb; }
+    public set volumeUnitDb(value: boolean) { 
+        this._volumeUnitDb = value == undefined ? true : value;      // true by default
+    }
+
+    private constructor(volumeUnitDb: boolean) {
+        this._volumeUnitDb = volumeUnitDb;
+    }
+
+    public static fromDefaultSetting(defaultSetting: PlayerDefault) {
+        // create instance
+        const setting = new PlayerSettingsService(true);
+
+        // init volume unit
+        setting.volumeUnitDb = defaultSetting.volumeUnitDb;
+
+        return setting;
+    }
+}

--- a/src/webview/service/playerSettingsService.ts
+++ b/src/webview/service/playerSettingsService.ts
@@ -9,7 +9,7 @@ export default class PlayerSettingsService {
     private _volumeUnitDb: boolean;
     public get volumeUnitDb() { return this._volumeUnitDb; }
     public set volumeUnitDb(value: boolean) { 
-        this._volumeUnitDb = value == undefined ? true : value;      // true by default
+        this._volumeUnitDb = value == undefined ? false : value;      // false by default
     }
 
     private _initVolumeDb: number;

--- a/src/webview/ui/playerComponent.ts
+++ b/src/webview/ui/playerComponent.ts
@@ -17,10 +17,10 @@ export default class PlayerComponent extends Disposable {
         parent.innerHTML = `
             <button id="play-button">play</button>
 
-            <div>volume</div>
+            <div id="volume-text">volume 100</div>
             <input type="range" id="volume-bar" value="100">
                         
-            <div>seekbar</div>
+            <div id="seek-pos-text">position 0.000 s</div>
             <div class="seek-bar-box">
                 <input type="range" id="seek-bar" value="0" />
                 <input type="range" id="user-input-seek-bar" class="input-seek-bar" value="0" />
@@ -39,15 +39,19 @@ export default class PlayerComponent extends Disposable {
             userinputSeekbar.value = "100";
         }));
         const visibleSeekbar = <HTMLInputElement>document.getElementById("seek-bar");
+        const seekPosText = <HTMLInputElement>document.getElementById("seek-pos-text");
         this._register(new Event(window, EventType.UpdateSeekbar, (e: CustomEventInit) => {
             visibleSeekbar.value = e.detail.value;
+            seekPosText.innerHTML = "position " + Number(e.detail.value).toFixed(3) + " s";
         }));
 
         // init volumebar
         this._volumeBar = <HTMLInputElement>document.getElementById("volume-bar");
+        const volumeText = <HTMLInputElement>document.getElementById("volume-text");
         this._register(new Event(this._volumeBar, EventType.Change, () => {
             // convert seekbar value(0~100) to volume(0~1)
             this._playerService.volume = Number(this._volumeBar.value) / 100;
+            volumeText.innerHTML = "volume " + this._volumeBar.value;
         }));
 
         // init play button

--- a/src/webview/ui/playerComponent.ts
+++ b/src/webview/ui/playerComponent.ts
@@ -51,7 +51,7 @@ export default class PlayerComponent extends Disposable {
         const seekPosText = <HTMLInputElement>document.getElementById("seek-pos-text");
         this._register(new Event(window, EventType.UpdateSeekbar, (e: CustomEventInit) => {
             visibleSeekbar.value = e.detail.value;
-            seekPosText.innerHTML = "position " + Number(e.detail.pos).toFixed(3) + " s";
+            seekPosText.textContent = "position " + Number(e.detail.pos).toFixed(3) + " s";
         }));
 
         // init volumebar
@@ -64,11 +64,11 @@ export default class PlayerComponent extends Disposable {
                 let voldb = Number(this._volumeBar.value)
                 let vollin = voldb == -80 ? 0 : Math.pow(10, voldb / 20)
                 this._playerService.volume = vollin;
-                volumeText.innerHTML = "volume " + (vollin == 0 ? "muted" : voldb.toFixed(1) + " dB");
+                volumeText.textContent = "volume " + (vollin == 0 ? "muted" : voldb.toFixed(1) + " dB");
             } else {
                 // convert seekbar value(0~100) to volume(0~1)
                 this._playerService.volume = Number(this._volumeBar.value) / 100;
-                volumeText.innerHTML = "volume " + this._volumeBar.value;
+                volumeText.textContent = "volume " + this._volumeBar.value;
             }
         }
         this._register(new Event(this._volumeBar, EventType.Input, updateVolume));

--- a/src/webview/ui/playerComponent.ts
+++ b/src/webview/ui/playerComponent.ts
@@ -48,7 +48,7 @@ export default class PlayerComponent extends Disposable {
         // init volumebar
         this._volumeBar = <HTMLInputElement>document.getElementById("volume-bar");
         const volumeText = <HTMLInputElement>document.getElementById("volume-text");
-        this._register(new Event(this._volumeBar, EventType.Change, () => {
+        this._register(new Event(this._volumeBar, EventType.Input, () => {
             // convert seekbar value(0~100) to volume(0~1)
             this._playerService.volume = Number(this._volumeBar.value) / 100;
             volumeText.innerHTML = "volume " + this._volumeBar.value;

--- a/src/webview/ui/playerComponent.ts
+++ b/src/webview/ui/playerComponent.ts
@@ -1,24 +1,33 @@
 import { Disposable } from '../../dispose';
 import { Event, EventType } from '../events';
 import PlayerService from '../service/playerService';
+import PlayerSettingsService from '../service/playerSettingsService';
 
 export default class PlayerComponent extends Disposable {
     private _playButton: HTMLButtonElement;
     private _volumeBar: HTMLInputElement;
     private _playerService: PlayerService;
+    private _playerSettingService: PlayerSettingsService;
 
-    constructor(parentID: string, playerService: PlayerService) {
+    constructor(parentID: string, playerService: PlayerService, playerSettingService: PlayerSettingsService) {
         super();
         this._playerService = playerService;
+        this._playerSettingService = playerSettingService;
         this._register(this._playerService);
         
         // init base html
         const parent = document.getElementById(parentID);
+
+        let volume_ui = this._playerSettingService.volumeUnitDb ?
+            `<div id="volume-text">volume 0.0dB</div>
+             <input type="range" id="volume-bar" value="0" min="-80" max="0" step="0.5">` :
+            `<div id="volume-text">volume 100</div>
+             <input type="range" id="volume-bar" value="100">`
+
         parent.innerHTML = `
             <button id="play-button">play</button>
 
-            <div id="volume-text">volume 0.0dB</div>
-            <input type="range" id="volume-bar" value="0" min="-80" max="0" step="0.5">
+            ${ volume_ui }
                         
             <div id="seek-pos-text">position 0.000 s</div>
             <div class="seek-bar-box">
@@ -49,12 +58,18 @@ export default class PlayerComponent extends Disposable {
         this._volumeBar = <HTMLInputElement>document.getElementById("volume-bar");
         const volumeText = <HTMLInputElement>document.getElementById("volume-text");
         this._register(new Event(this._volumeBar, EventType.Input, () => {
-            // convert dB setting to linear gain
-            // -80dB is treated as mute
-            let voldb = Number(this._volumeBar.value)
-            let vollin = voldb == -80 ? 0 : Math.pow(10, voldb / 20)
-            this._playerService.volume = vollin;
-            volumeText.innerHTML = "volume " + (vollin == 0 ? "muted" : voldb.toFixed(1) + " dB");
+            if (this._playerSettingService.volumeUnitDb) {
+                // convert dB setting to linear gain
+                // -80dB is treated as mute
+                let voldb = Number(this._volumeBar.value)
+                let vollin = voldb == -80 ? 0 : Math.pow(10, voldb / 20)
+                this._playerService.volume = vollin;
+                volumeText.innerHTML = "volume " + (vollin == 0 ? "muted" : voldb.toFixed(1) + " dB");
+            } else {
+                // convert seekbar value(0~100) to volume(0~1)
+                this._playerService.volume = Number(this._volumeBar.value) / 100;
+                volumeText.innerHTML = "volume " + this._volumeBar.value;
+            }
         }));
 
         // init play button

--- a/src/webview/ui/playerComponent.ts
+++ b/src/webview/ui/playerComponent.ts
@@ -57,7 +57,7 @@ export default class PlayerComponent extends Disposable {
         // init volumebar
         this._volumeBar = <HTMLInputElement>document.getElementById("volume-bar");
         const volumeText = <HTMLInputElement>document.getElementById("volume-text");
-        this._register(new Event(this._volumeBar, EventType.Input, () => {
+        const updateVolume = () => {
             if (this._playerSettingService.volumeUnitDb) {
                 // convert dB setting to linear gain
                 // -80dB is treated as mute
@@ -70,7 +70,10 @@ export default class PlayerComponent extends Disposable {
                 this._playerService.volume = Number(this._volumeBar.value) / 100;
                 volumeText.innerHTML = "volume " + this._volumeBar.value;
             }
-        }));
+        }
+        this._register(new Event(this._volumeBar, EventType.Input, updateVolume));
+        this._volumeBar.value = String(this._playerSettingService.volumeUnitDb ? this._playerSettingService.initVolumeDb : this._playerSettingService.initVolume);
+        updateVolume();
 
         // init play button
         this._playButton = <HTMLButtonElement>document.getElementById("play-button");

--- a/src/webview/ui/playerComponent.ts
+++ b/src/webview/ui/playerComponent.ts
@@ -51,8 +51,8 @@ export default class PlayerComponent extends Disposable {
         this._register(new Event(this._volumeBar, EventType.Input, () => {
             // convert dB setting to linear gain
             // -80dB is treated as mute
-            var voldb = Number(this._volumeBar.value)
-            var vollin = voldb == -80 ? 0 : Math.pow(10, voldb / 20)
+            let voldb = Number(this._volumeBar.value)
+            let vollin = voldb == -80 ? 0 : Math.pow(10, voldb / 20)
             this._playerService.volume = vollin;
             volumeText.innerHTML = "volume " + (vollin == 0 ? "muted" : voldb.toFixed(1) + " dB");
         }));

--- a/src/webview/ui/playerComponent.ts
+++ b/src/webview/ui/playerComponent.ts
@@ -51,7 +51,7 @@ export default class PlayerComponent extends Disposable {
         const seekPosText = <HTMLInputElement>document.getElementById("seek-pos-text");
         this._register(new Event(window, EventType.UpdateSeekbar, (e: CustomEventInit) => {
             visibleSeekbar.value = e.detail.value;
-            seekPosText.innerHTML = "position " + Number(e.detail.value).toFixed(3) + " s";
+            seekPosText.innerHTML = "position " + Number(e.detail.pos).toFixed(3) + " s";
         }));
 
         // init volumebar

--- a/src/webview/ui/playerComponent.ts
+++ b/src/webview/ui/playerComponent.ts
@@ -17,8 +17,8 @@ export default class PlayerComponent extends Disposable {
         parent.innerHTML = `
             <button id="play-button">play</button>
 
-            <div id="volume-text">volume 100</div>
-            <input type="range" id="volume-bar" value="100">
+            <div id="volume-text">volume 0.0dB</div>
+            <input type="range" id="volume-bar" value="0" min="-80" max="0" step="0.5">
                         
             <div id="seek-pos-text">position 0.000 s</div>
             <div class="seek-bar-box">
@@ -49,9 +49,12 @@ export default class PlayerComponent extends Disposable {
         this._volumeBar = <HTMLInputElement>document.getElementById("volume-bar");
         const volumeText = <HTMLInputElement>document.getElementById("volume-text");
         this._register(new Event(this._volumeBar, EventType.Input, () => {
-            // convert seekbar value(0~100) to volume(0~1)
-            this._playerService.volume = Number(this._volumeBar.value) / 100;
-            volumeText.innerHTML = "volume " + this._volumeBar.value;
+            // convert dB setting to linear gain
+            // -80dB is treated as mute
+            var voldb = Number(this._volumeBar.value)
+            var vollin = voldb == -80 ? 0 : Math.pow(10, voldb / 20)
+            this._playerService.volume = vollin;
+            volumeText.innerHTML = "volume " + (vollin == 0 ? "muted" : voldb.toFixed(1) + " dB");
         }));
 
         // init play button

--- a/src/webview/ui/webview.ts
+++ b/src/webview/ui/webview.ts
@@ -9,6 +9,7 @@ import { Config } from "../../config";
 import Decoder from "../decoder";
 import AnalyzeSettingsService from "../service/analyzeSettingsService";
 import AnalyzeService from "../service/analyzeService";
+import PlayerSettingsService from "../service/playerSettingsService";
 
 type createAudioContext = (sampleRate: number) => AudioContext;
 type createDecoder = (fileData: Uint8Array) => Promise<Decoder>;
@@ -124,7 +125,8 @@ export default class WebView {
         }
         // init player
         const playerService = new PlayerService(audioContext, audioBuffer);
-        const playerComponent = new PlayerComponent("player", playerService);
+        const playerSettingsService = PlayerSettingsService.fromDefaultSetting(this._config.playerDefault)
+        const playerComponent = new PlayerComponent("player", playerService, playerSettingsService);
         this._disposables.push(playerService, playerComponent);
         // init analyzer
         const analyzeService = new AnalyzeService(audioBuffer);


### PR DESCRIPTION
This pull request introduces changes to enhance player usability.

## Purpose of Change
* To improve player usability.

## Changes
* Add displays for volume and playback position.
	* This allows users to easily confirm their current status.
* Moving the volume bar immediately affects the volume, without waiting for it to be released.
	* This makes volume control more intuitive for the user.
* Change the default volume scale to dB. **!! caution: breaking change !!**
	* This allows users to control lower volumes more precisely.
	* The current linear scale can still be selected in the settings.
	* Although this is a breaking change, I believe it will not greatly confuse current users since the scale is not currently explicitly mentioned.
* Add settings to set the initial volume.
	* This allows users to set a default volume that matches their environment.
* Add setting explanation to README.md.

![pr_player_bar](https://github.com/sukumo28/vscode-audio-preview/assets/2169305/2c1bc27f-7cbe-44cc-8817-5497005c3ae7)

![pr_player_settings](https://github.com/sukumo28/vscode-audio-preview/assets/2169305/7cb9f93d-388b-4224-8af7-15374c84e4a3)

## Tests
* I've confirmed the change visually.
* Add tests for the newly defined class, PlayerSettingService (playerSettingsService.test.ts).
* Some tests have been modified to assess the volume display and volume change behavior.
* The changes are compatible with all existing tests, including those added or modified.

As I am new to VSCode extension, TypeScript, and GitHub practices, I welcome any feedback.