### PR TITLE
Feature improve waveform

### DIFF
--- a/src/webview/components/waveform/waveFormComponent.ts
+++ b/src/webview/components/waveform/waveFormComponent.ts
@@ -106,7 +106,11 @@ export default class WaveFormComponent {
       const x = (i / data.length) * width;
       const y = height * (1 - d);
 
-      if (data.length > AnalyzeSettingsService.WAVEFORM_CANVAS_WIDTH * WaveFormComponent.MIN_DATA_POINTS_PER_PIXEL) {
+      if (
+        data.length >
+        AnalyzeSettingsService.WAVEFORM_CANVAS_WIDTH *
+          WaveFormComponent.MIN_DATA_POINTS_PER_PIXEL
+      ) {
         context.fillRect(x, y, 1, 1);
       } else {
         if (i === 0) {

--- a/src/webview/components/waveform/waveFormComponent.ts
+++ b/src/webview/components/waveform/waveFormComponent.ts
@@ -1,8 +1,11 @@
 import "../../styles/figure.css";
 import AnalyzeService from "../../services/analyzeService";
+import AnalyzeSettingsService from "../../services/analyzeSettingsService";
 import { AnalyzeSettingsProps } from "../../services/analyzeSettingsService";
 
 export default class WaveFormComponent {
+  public static readonly MIN_DATA_POINTS_PER_PIXEL = 5;
+
   constructor(
     componentRootSelector: string,
     width: number,
@@ -21,6 +24,7 @@ export default class WaveFormComponent {
     canvas.height = height;
     const context = canvas.getContext("2d", { alpha: false });
     context.fillStyle = "rgb(160,60,200)";
+    context.strokeStyle = "rgb(160,60,200)";
     componentRoot.appendChild(canvas);
 
     const axisCanvas = document.createElement("canvas");
@@ -101,7 +105,20 @@ export default class WaveFormComponent {
 
       const x = (i / data.length) * width;
       const y = height * (1 - d);
-      context.fillRect(x, y, 1, 1);
+
+      if (data.length > AnalyzeSettingsService.WAVEFORM_CANVAS_WIDTH * WaveFormComponent.MIN_DATA_POINTS_PER_PIXEL) {
+        context.fillRect(x, y, 1, 1);
+      } else {
+        if (i === 0) {
+          context.beginPath();
+          context.moveTo(x, y);
+        } else if (i === data.length - 1) {
+          context.lineTo(x, y);
+          context.stroke();
+        } else {
+          context.lineTo(x, y);
+        }
+      }
     }
 
     // draw channel label


### PR DESCRIPTION
This PR improves the drawing of the waveform when only a few data points are selected.

## Purpose of Change
* To enhance visibility when the user magnifies the time scale.

## Changes
* If the number of data points in the selected range is less than five times the drawing width, the data is drawn with lines instead of points.

![pr_spectrogram_drawing](https://github.com/sukumo28/vscode-audio-preview/assets/2169305/06fb0ad8-e323-44b3-8027-6335f3b4da6c)

## Tests
* I've confirmed the changes visually.
* The changes conform to all existing tests.